### PR TITLE
根据package.json中useNpmInstall属性如果不为true或者没有配置该属性，则认为使用cnpm来安装依赖。

### DIFF
--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -12,6 +12,79 @@ var util = require('./util');
 var _ = fis.util;
 
 /**
+ * 判断一个模块是否已经安装过
+ * @param  {String}  moduleName 需要判断的模块的名字
+ * @return {Boolean}            已安装返回true，否则返回false
+ */
+function isModuleAvailableSync(moduleName) {
+    try {
+        if (require.resolve(moduleName)) {
+            return true;
+        } else {
+            return false;
+        }
+    } catch (e) {
+        //console.error("%s is not found", moduleName);
+        //process.exit(e.code);
+        return false;
+    }
+}
+
+/**
+ * 判断cnpm是否存在，不存在安装 cnpm
+ *
+ * @param {Object} options 选项
+ * @param {Object} info 模板信息
+ * @return {Promise|Object}
+ */
+function installCnpm(options, info) {
+    var packageJson = path.join(options.root, 'package.json');
+
+    if (!util.isFileExists(packageJson)) {
+        return info;
+    }
+
+    try {
+        var config = require(packageJson);
+        if (config.useNpmInstall) {
+            //如果在package.json配置useNpmInstall:true,则不用cnpm安装
+            return info;
+        }
+        fis.log.info('use cnpm install dependencies ...');
+        //判断cnpm是否安装
+        if (isModuleAvailableSync('cnpm')) {
+            //cnpm已经安装
+            fis.log.info('cnpm has installed ...')
+            return info;
+        } else {
+            //cnpm 没有安装，需要安装到global
+            return new Promise(function(resolve, reject) {
+                var child_process = require('child_process');
+                var spawn = child_process.spawn;
+                var npm = _.isWin() ? 'npm.cmd' : 'npm';
+                fis.log.info('now install cnpm to global ...');
+                //最新版本的cnpm是用es6写的，低版本的node不支持
+                var install = spawn(npm, ['install', 'cnpm@3.4.1', '-g'], {
+                    cwd: options.root
+                });
+
+                install.stdout.pipe(process.stdout);
+                install.stderr.pipe(process.stderr);
+                install.on('error', function(reason) {
+                    reject(reason);
+                });
+                install.on('close', function() {
+                    resolve(info);
+                });
+            });
+        }
+    } catch (ex) {
+        fis.log.warn(ex);
+    }
+
+}
+
+/**
  * 安装 npm 依赖
  *
  * @param {Object} options 选项
@@ -30,11 +103,14 @@ function installNPMDependence(options, info) {
         if (config.dependencies || config.devDependencies) {
             fis.log.info('Installing npm dependencies...');
 
-            // run `npm install`
+            // run `npm/cnpm install`
             return new Promise(function (resolve, reject) {
                 var child_process = require('child_process');
                 var spawn = child_process.spawn;
-                var npm = _.isWin() ? 'npm.cmd' : 'npm';
+                var npm = _.isWin() ? 'cnpm.cmd' : 'cnpm';
+                if(config.useNpmInstall){
+                    npm = _.isWin() ? 'npm.cmd' : 'npm';
+                }
                 var install = spawn(npm, ['install'], {
                     cwd: options.root
                 });
@@ -142,6 +218,7 @@ function initProject(scaffold, options) {
             fis.log.info('Init project in dir: %s', options.target);
             return tplLoader.load(scaffold, options);
         })
+        .then(installCnpm.bind(this,options))
         .then(installNPMDependence.bind(this, options))
         .then(installProjectComponents.bind(this, options, options.solutionName))
         .then(function () {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "etpl": "^3.0.1",
     "findup": "^0.1.5",
     "fis-scaffold-kernel": "^0.1.1"
-  }
+  },
+  "useNpmInstall":false
 }


### PR DESCRIPTION
fiss init之后先判断cnpm是否安装，如果没有安装，先安装cnpm，再用cnpm安装依赖。
